### PR TITLE
Feature date range

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ License: GPL-3
 Encoding: UTF-8
 Language: en
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Imports: 
     glue,
     jsonlite,

--- a/R/cmip-download.R
+++ b/R/cmip-download.R
@@ -2,7 +2,7 @@
 #'
 #' @param results A list of search results from [cmip_search()].
 #' @param root Root folder to download and organise the data.
-#' @param year_range A n integer vector of length 2, indicating the start and end range of years. Restricts the download of model output with files that include some data within this range of years. Defaults to c(-Inf, Inf) to include all possible files
+#' @param year_range An integer vector of length 2, indicating the start and end range of years. Restricts the download of model output with files that include some data within this range of years. Defaults to c(-Inf, Inf) to include all possible files
 #' @param user,comment Optional strings to use when saving the log for each file.
 #' @param ... Ignored
 #'

--- a/R/cmip-download.R
+++ b/R/cmip-download.R
@@ -2,8 +2,8 @@
 #'
 #' @param results A list of search results from [cmip_search()].
 #' @param root Root folder to download and organise the data.
-#' @param year_start Restrict the download of model output with files that include at least some data after this year. Defaults to 1850 to include all possible files
-#' @param year_end Restrict the download of model output with files that include at least some data before this year. Defaults to 2300 to include all possible files
+#' @param year_start Restrict the download of model output with files that include at least some data after this year. Defaults to -Inf to include all possible files
+#' @param year_end Restrict the download of model output with files that include at least some data before this year. Defaults to Inf to include all possible files
 #' @param user,comment Optional strings to use when saving the log for each file.
 #' @param ... Ignored
 #'
@@ -11,7 +11,7 @@
 #' A list of files.
 #'
 #' @export
-cmip_download <- function(results, root = cmip_root_get(), year_start = 1850, year_end = 2300, user = Sys.info()[["user"]], comment = NULL, ...) {
+cmip_download <- function(results, root = cmip_root_get(), year_start = -Inf, year_end = Inf, user = Sys.info()[["user"]], comment = NULL, ...) {
 
   if(year_start > year_end) {
     stop("The start date can not be after the end date")

--- a/R/cmip-download.R
+++ b/R/cmip-download.R
@@ -10,7 +10,7 @@
 #' A list of files.
 #'
 #' @export
-cmip_download <- function(results, root = cmip_root_get(), year_range = c(-Inf, Inf), user = Sys.info()[["user"]], comment = NULL, ...) {
+cmip_download <- function(results, root = cmip_root_get(), user = Sys.info()[["user"]], comment = NULL, year_range = c(-Inf, Inf), ...) {
 
   if(year_range[1] > year_range[2]) {
     stop("The start date can not be after the end date")

--- a/R/cmip-download.R
+++ b/R/cmip-download.R
@@ -28,7 +28,7 @@ cmip_download <- function(results, root = cmip_root_get(), user = Sys.info()[["u
   }
 
   files <- lapply(seq_len(nrow(results)), function(i) {
-    cmip_download_one(results[i, ], year_range = year_range, root = root, user = user, comment = comment, ...)
+    cmip_download_one(results[i, ], root = root, user = user, comment = comment,  year_range = year_range, ...)
   })
 
   downloaded <- vapply(files, function(x) all(!is.na(x)), logical(1))

--- a/R/cmip-download.R
+++ b/R/cmip-download.R
@@ -55,7 +55,7 @@ instance_query <- function(x) {
   paste0(start, x, "\"))")
 }
 
-cmip_download_one <- function(result, root = cmip_root_get(), year_range = year_range, user = Sys.info()[["user"]], comment = NULL, ...) {
+cmip_download_one <- function(result, root = cmip_root_get(), user = Sys.info()[["user"]], comment = NULL,  year_range = year_range, ...) {
   dir <- result_dir(result, root = root)
 
   use_https <- list(...)[["use_https"]]

--- a/R/cmip-download.R
+++ b/R/cmip-download.R
@@ -13,7 +13,7 @@
 cmip_download <- function(results, root = cmip_root_get(), user = Sys.info()[["user"]], comment = NULL, year_range = c(-Inf, Inf), ...) {
 
   if(year_range[1] > year_range[2]) {
-    stop("The start date can not be after the end date")
+    stop(tr_("The start year cannot be greater than the end year"))
   }
 
   root <- path.expand(root)

--- a/man/cmip_download.Rd
+++ b/man/cmip_download.Rd
@@ -7,8 +7,7 @@
 cmip_download(
   results,
   root = cmip_root_get(),
-  year_start = -Inf,
-  year_end = Inf,
+  year_range = c(-Inf, Inf),
   user = Sys.info()[["user"]],
   comment = NULL,
   ...
@@ -19,9 +18,7 @@ cmip_download(
 
 \item{root}{Root folder to download and organise the data.}
 
-\item{year_start}{Restrict the download of model output with files that include at least some data after this year. Defaults to -Inf to include all possible files}
-
-\item{year_end}{Restrict the download of model output with files that include at least some data before this year. Defaults to Inf to include all possible files}
+\item{year_range}{A n integer vector of length 2, indicating the start and end range of years. Restricts the download of model output with files that include some data within this range of years. Defaults to c(-Inf, Inf) to include all possible files}
 
 \item{user, comment}{Optional strings to use when saving the log for each file.}
 

--- a/man/cmip_download.Rd
+++ b/man/cmip_download.Rd
@@ -7,6 +7,8 @@
 cmip_download(
   results,
   root = cmip_root_get(),
+  year_start = -Inf,
+  year_end = Inf,
   user = Sys.info()[["user"]],
   comment = NULL,
   ...
@@ -16,6 +18,10 @@ cmip_download(
 \item{results}{A list of search results from \code{\link[=cmip_search]{cmip_search()}}.}
 
 \item{root}{Root folder to download and organise the data.}
+
+\item{year_start}{Restrict the download of model output with files that include at least some data after this year. Defaults to -Inf to include all possible files}
+
+\item{year_end}{Restrict the download of model output with files that include at least some data before this year. Defaults to Inf to include all possible files}
 
 \item{user, comment}{Optional strings to use when saving the log for each file.}
 

--- a/tests/testthat/test-cmip_search.R
+++ b/tests/testthat/test-cmip_search.R
@@ -71,14 +71,14 @@ test_that("Download works", {
   expect_error(cmip_root_set(root), NA)
   expect_equal(cmip_root_get(), root)
 
-  suppressMessages(expect_type(files <- cmip_download(results[c(1:2)]), "list"))
+  suppressMessages(expect_type(files <- cmip_download(results[c(3:4)]), "list"))
   expect_length(files, 2)
   expect_type(files[[1]], "character")
 
   expect_true(all(file.exists(unlist(files))))
-  suppressMessages(expect_message(cmip_download(results[1]), "Skipping"))
+  suppressMessages(expect_message(cmip_download(results[3]), "Skipping"))
 
-  suppressMessages(expect_type(files_simple <- cmip_download(cmip_simplify(results)[1:2]), "list"))
+  suppressMessages(expect_type(files_simple <- cmip_download(cmip_simplify(results)[3:4]), "list"))
   expect_equal(files, files_simple)
 })
 
@@ -92,7 +92,7 @@ test_that("cmip_available() works", {
 
   available <- available[, colnames(results), with = FALSE]
 
-  expect_equal(results[c(1:2)][order(id)],
+  expect_equal(results[c(3:4)][order(id)],
                available[order(id)])
 })
 

--- a/tests/testthat/test-cmip_search.R
+++ b/tests/testthat/test-cmip_search.R
@@ -97,3 +97,34 @@ test_that("cmip_available() works", {
 })
 
 
+########
+query <- list(
+  type          = "Dataset",
+  replica       = "true", # esg-dn2.nsc.liu.se Is down... again
+  latest        = "true",
+  variable_id   = "tos",
+  project       = "CMIP6",
+  grid_label    = "gn",
+  frequency     = "day",
+  table_id      = "Oday",
+  experiment_id = "historical",
+  member_id     = "r1i1p1f1",
+  source_id     = "EC-Earth3" # This one has one file per year, ideal to test the range function
+)
+
+results <- cmip_search(query) %>%
+  head(1)
+
+test_that("year_range argument in cmip_download works", {
+  expect_error(cmip_root_set(root), NA)
+  expect_equal(cmip_root_get(), root)
+
+  expect_error(files <- cmip_download(results, year_range = c(1993, 1992)))
+  suppressMessages(expect_type(files <- cmip_download(results, year_range = c(1993, 1994)), "list"))
+
+  expect_length(files, 1)
+  expect_type(files[[1]], "character")
+
+  expect_false(all(file.exists(unlist(files))))
+  expect_equal(sum(file.exists(unlist(files))), 2)
+})


### PR DESCRIPTION
This pull request addresses https://github.com/eliocamp/rcmip6/issues/7, and includes two new parameters where the user can specify the start and and dates (year, integer) for which they require data. Ultimately, this results in faster download because not all files of a given model have to be downloaded.

All tests passed locally with

```
> sessionInfo()
R version 4.2.2 (2022-10-31)
Platform: x86_64-apple-darwin17.0 (64-bit)
Running under: macOS Ventura 13.0.1

Matrix products: default
LAPACK: /Library/Frameworks/R.framework/Versions/4.2/Resources/lib/libRlapack.dylib

locale:
[1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

loaded via a namespace (and not attached):
[1] compiler_4.2.2  tools_4.2.2     rstudioapi_0.14
```

Two tests had to be modified as the esgf-data.ucar.edu is currently down.


